### PR TITLE
[unique.ptr.single] Align preconditions and postconditions with the g…

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2330,7 +2330,7 @@ nothing, value-initializing the stored pointer and the stored deleter.
 
 \pnum
 \ensures
-\tcode{get() == nullptr}. \tcode{get_deleter()}
+\tcode{get() == nullptr} is \tcode{true}. \tcode{get_deleter()}
 returns a reference to the stored deleter.
 \end{itemdescr}
 
@@ -2358,7 +2358,7 @@ value-initializing the stored deleter.
 
 \pnum
 \ensures
-\tcode{get() == p}. \tcode{get_deleter()}
+\tcode{get() == p} is \tcode{true}. \tcode{get_deleter()}
 returns a reference to the stored deleter.
 \end{itemdescr}
 
@@ -2390,7 +2390,7 @@ from \tcode{std::forward<decltype(d)>(d)}.
 
 \pnum
 \ensures
-\tcode{get() == p}.
+\tcode{get() == p} is \tcode{true}.
 \tcode{get_deleter()} returns a reference to the stored
 deleter. If \tcode{D} is a reference type then \tcode{get_deleter()}
 returns a reference to the lvalue \tcode{d}.

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2446,7 +2446,7 @@ construction of the deleter can be implemented with \tcode{std::forward<D>}.
 \pnum
 \ensures
 \tcode{get()} yields the value \tcode{u.get()}
-yielded before the construction. \tcode{u.get() == nullptr}.
+yielded before the construction. \tcode{u.get() == nullptr} is \tcode{true}.
 \tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
 \tcode{u.get_deleter()}. If \tcode{D} is a reference type then
@@ -2492,7 +2492,7 @@ The deleter constructor can be implemented with
 \pnum
 \ensures
 \tcode{get()} yields the value \tcode{u.get()}
-yielded before the construction. \tcode{u.get() == nullptr}.
+yielded before the construction. \tcode{u.get() == nullptr} is \tcode{true}.
 \tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
 \tcode{u.get_deleter()}.
@@ -2549,8 +2549,8 @@ Calls \tcode{reset(u.release())} followed by
 
 \pnum
 \ensures
-If \tcode{this != addressof(u)},
-\tcode{u.get() == nullptr},
+If \tcode{this != addressof(u)} is \tcode{true},
+\tcode{u.get() == nullptr} is \tcode{true},
 otherwise \tcode{u.get()} is unchanged.
 
 \pnum
@@ -2588,7 +2588,7 @@ Calls \tcode{reset(u.release())} followed by
 
 \pnum
 \ensures
-\tcode{u.get() == nullptr}.
+\tcode{u.get() == nullptr} is \tcode{true}.
 
 \pnum
 \returns
@@ -2607,7 +2607,7 @@ As if by \tcode{reset()}.
 
 \pnum
 \ensures
-\tcode{get() == nullptr}.
+\tcode{get() == nullptr} is \tcode{true}.
 
 \pnum
 \returns
@@ -2644,7 +2644,7 @@ constexpr pointer operator->() const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{get() != nullptr}.
+\tcode{get() != nullptr} is \tcode{true}.
 
 \pnum
 \returns
@@ -2700,7 +2700,7 @@ constexpr pointer release() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{get() == nullptr}.
+\tcode{get() == nullptr} is \tcode{true}.
 
 \pnum
 \returns
@@ -2726,7 +2726,7 @@ because the call to \tcode{get_deleter()} might destroy \tcode{*this}.
 
 \pnum
 \ensures
-\tcode{get() == p}.
+\tcode{get() == p} is \tcode{true}.
 \begin{note}
 The postcondition does not hold if the call to \tcode{get_deleter()}
 destroys \tcode{*this} since \tcode{this->get()} is no longer a valid expression.


### PR DESCRIPTION
…uidelines

According to https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines#formatting-declarations-and-definitions, conditions should be expressed as `<expr> is true` instead of simply `<expr>`. It seems that `std::unique_ptr` specification does not comply with that.

This PR updates all such places that I have spotted.